### PR TITLE
18.06 pr更新 2021.5.20

### DIFF
--- a/themes/luci-theme-material/htdocs/luci-static/material/js/script.js
+++ b/themes/luci-theme-material/htdocs/luci-static/material/js/script.js
@@ -139,8 +139,12 @@
         var onclick = that.attr("onclick");
         if (onclick == undefined || onclick == "") {
             that.click(function () {
+                var target = that.attr("target");
                 var href = that.attr("href");
-                if (href.indexOf("#") == -1) {
+                if ((target == undefined || target == "" || target == "_self")
+                    && href != undefined
+                    && href.indexOf("#") != 0
+                    && href.indexOf("javascript:") != 0) {
                     $(".main > .loading").fadeIn("fast");
                     return true;
                 }


### PR DESCRIPTION
After opening an external hyperlink in a new browser tab, LuCI hangs in the
load screen. This commit will fix this issue.